### PR TITLE
Extract the ability to check whether or not a voice channel is curren…

### DIFF
--- a/cmd/bot/zahtbot.go
+++ b/cmd/bot/zahtbot.go
@@ -17,7 +17,8 @@ import (
 type ZahtBot struct {
 	*disgord.Client
 
-	voiceStateCache cache.VoiceStateCache
+	voiceStateCache cache.VoiceState
+	guildStateCache cache.GuildState
 
 	thumbnailURL string
 	commands     []command.Command
@@ -50,6 +51,7 @@ func NewZahtBot(botToken string) (*ZahtBot, error) {
 		}),
 
 		voiceStateCache: memory.NewVoiceStateCache(),
+		guildStateCache: memory.NewGuildStateCache(),
 
 		thumbnailURL: "https://www.cla.purdue.edu/facultyStaff/profiles/new/newfaculty-17/full/Sweet_Jonathan.jpg",
 		commands: []command.Command{
@@ -131,17 +133,4 @@ func (zb *ZahtBot) getVoiceChannelID(session disgord.Session, evt *disgord.Messa
 	}
 
 	return vs.ChannelID
-}
-
-func (zb *ZahtBot) isVoiceChannelActive(channelID disgord.Snowflake) bool {
-	_, ok := zb.activeChannels[channelID]
-	return ok
-}
-
-func (zb *ZahtBot) lockVoiceChannel(channelID disgord.Snowflake, soundName string) {
-	zb.activeChannels[channelID] = soundName
-}
-
-func (zb *ZahtBot) unlockVoiceChannel(channelID disgord.Snowflake) {
-	delete(zb.activeChannels, channelID)
 }

--- a/internal/cache/memory/guildstatecache.go
+++ b/internal/cache/memory/guildstatecache.go
@@ -1,0 +1,60 @@
+package memory
+
+import (
+	"sync"
+
+	"github.com/andersfylling/disgord"
+)
+
+// GuildStateCache tracks what guilds the bot is actively playing a sound in.
+type GuildStateCache struct {
+	activeGuilds map[disgord.Snowflake]*guildState
+	mutex        sync.RWMutex
+}
+
+// guildState is what/where the bot is currently actively playing a sound.
+type guildState struct {
+	guildID   disgord.Snowflake
+	channelID disgord.Snowflake
+	soundName string
+}
+
+// NewGuildStateCache returns a new GuildStateCache.
+func NewGuildStateCache() *GuildStateCache {
+	return &GuildStateCache{
+		activeGuilds: make(map[disgord.Snowflake]*guildState),
+	}
+}
+
+// IsActive returns whether the bot is actively playing a sound in any of the given guild's voice channels.
+func (c *GuildStateCache) IsActive(guildID disgord.Snowflake) (active bool, channelID disgord.Snowflake, soundName string) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	guildState, ok := c.activeGuilds[guildID]
+	if !ok {
+		return ok, disgord.ParseSnowflakeString(""), ""
+	}
+
+	return ok, guildState.channelID, guildState.soundName
+}
+
+// Lock marks a guild as 'actively being played in'.
+func (c *GuildStateCache) Lock(guildID, channelID disgord.Snowflake, soundName string) {
+	c.mutex.Lock()
+	c.mutex.Unlock()
+
+	c.activeGuilds[guildID] = &guildState{
+		guildID:   guildID,
+		channelID: channelID,
+		soundName: soundName,
+	}
+}
+
+// Unlock releases a guild from being marked as 'actively being played in'.
+func (c *GuildStateCache) Unlock(guildID disgord.Snowflake) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	delete(c.activeGuilds, guildID)
+}

--- a/internal/cache/models.go
+++ b/internal/cache/models.go
@@ -2,11 +2,18 @@ package cache
 
 import "github.com/andersfylling/disgord"
 
-// VoiceStateCache caches Disgord voice states.
-type VoiceStateCache interface {
+// VoiceState caches Disgord voice states.
+type VoiceState interface {
 	Handle(disgord.Session, *disgord.VoiceState) error
 	AddVoiceState(*disgord.VoiceState)
 	GetVoiceState(disgord.Snowflake) (int, *disgord.VoiceState)
 	UpdateVoiceState(disgord.Snowflake, *disgord.VoiceState)
 	DeleteVoiceState(disgord.Snowflake)
+}
+
+// GuildState caches channel activity.
+type GuildState interface {
+	IsActive(disgord.Snowflake) (bool, disgord.Snowflake, string)
+	Lock(disgord.Snowflake, disgord.Snowflake, string)
+	Unlock(disgord.Snowflake)
 }


### PR DESCRIPTION
…tly being played in into an internal library. Replace the condition of a voice channel being 'in-use' with a guild being 'in-use' due to the fact that a bot can only actively participate in a single voice channel per-guild, just like a normal user. Add sync.RWMutex to both the GuildStateCache and VoiceStateCache libraries to make them thread-safe.